### PR TITLE
Switch PrometheusStatsReceiver default timer to JavaTimer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 organization := "com.samstarling"
 
-val finagleVersion = "18.6.0"
+val finagleVersion = "18.2.0"
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-core" % finagleVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 organization := "com.samstarling"
 
-val finagleVersion = "18.2.0"
+val finagleVersion = "18.6.0"
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-core" % finagleVersion,

--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -10,9 +10,9 @@ import com.twitter.util._
 class PrometheusStatsReceiver(registry: CollectorRegistry, namespace: String, timer: Timer, gaugePollInterval: Duration)
   extends StatsReceiver with Closable {
 
-  def this() = this(CollectorRegistry.defaultRegistry, "finagle", DefaultTimer.getInstance, Duration.fromSeconds(10))
+  def this() = this(CollectorRegistry.defaultRegistry, "finagle", new JavaTimer(), Duration.fromSeconds(10))
 
-  def this(registry: CollectorRegistry) = this(registry, "finagle", DefaultTimer.getInstance, Duration.fromSeconds(10))
+  def this(registry: CollectorRegistry) = this(registry, "finagle", new JavaTimer(), Duration.fromSeconds(10))
 
   protected val counters = TrieMap.empty[String, PCounter]
   protected val summaries = TrieMap.empty[String, Summary]


### PR DESCRIPTION
When using `PrometheusStatsReceiver` in `resources/META-INF/services/com.twitter.finagle.stats.StatsReceiver`, we were getting a null pointer exception:

```
SEVERE: LoadService: failed to instantiate 'com.samstarling.prometheusfinagle.PrometheusStatsReceiver' for the requested service 'com.twitter.finagle.stats.StatsReceiver'
java.lang.NullPointerException
	at com.twitter.finagle.util.DefaultTimer$.toString(DefaultTimer.scala:94)
	at java.lang.String.valueOf(String.java:2994)
	at java.io.PrintStream.println(PrintStream.java:821)
	at scala.Console$.println(Console.scala:267)
	at scala.Predef$.println(Predef.scala:393)
	at com.samstarling.prometheusfinagle.PrometheusStatsReceiver.<init>(PrometheusStatsReceiver.scala:28)
	at com.samstarling.prometheusfinagle.PrometheusStatsReceiver.<init>(PrometheusStatsReceiver.scala:13)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
```

I did some debugging, and it turns out that at the time the argument-less `new PrometheusStatsReceiver()` constructor is called, both `DefaultTimer` is `null`. I'm not super familiar with how/when the Java service discovery stuff works, so I'm not exactly sure _why_ it's `null`.

In any event, switching the timer to a new `JavaTimer` instance seems to fix it. I'm also not sure on if `JavaTimer` is the best timer to use -- it's the one I'm most familiar with and have used in various projects with success. But let me know if you have a different idea.

Also, I'm not sure how to test this behavior. In running the test suite, the service loader logic does run and the `NullPointerException` was raised, but no test is really able to exercise that behavior I think? I'd like to add a test, so if you know a way to do that, let me know.