### PR TITLE
Fall back to a JavaTimer if a DefaultTimer instance can't be fetched

### DIFF
--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -8,7 +8,7 @@ import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
 
 private object CustomDefaultTimer {
-  def getInstance: Timer = Option(DefaultTimer.getInstance).getOrElse(new JavaTimer())
+  def getInstance: Timer = Option(DefaultTimer.getInstance).getOrElse(new JavaTimer(isDaemon = true))
 }
 
 class PrometheusStatsReceiver(registry: CollectorRegistry, namespace: String, timer: Timer, gaugePollInterval: Duration)

--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -7,12 +7,16 @@ import scala.collection.concurrent.TrieMap
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util._
 
+private object CustomDefaultTimer {
+  def getInstance: Timer = Option(DefaultTimer.getInstance).getOrElse(new JavaTimer())
+}
+
 class PrometheusStatsReceiver(registry: CollectorRegistry, namespace: String, timer: Timer, gaugePollInterval: Duration)
   extends StatsReceiver with Closable {
 
-  def this() = this(CollectorRegistry.defaultRegistry, "finagle", DefaultTimer.getInstance, Duration.fromSeconds(10))
+  def this() = this(CollectorRegistry.defaultRegistry, "finagle", CustomDefaultTimer.getInstance, Duration.fromSeconds(10))
 
-  def this(registry: CollectorRegistry) = this(registry, "finagle", DefaultTimer.getInstance, Duration.fromSeconds(10))
+  def this(registry: CollectorRegistry) = this(registry, "finagle", CustomDefaultTimer.getInstance, Duration.fromSeconds(10))
 
   protected val counters = TrieMap.empty[String, PCounter]
   protected val summaries = TrieMap.empty[String, Summary]

--- a/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverTest.scala
+++ b/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverTest.scala
@@ -32,7 +32,7 @@ class PrometheusStatsReceiverTest extends UnitTest {
     "allow a registry, namespace, and a Timer to be passed" in {
       val registry = CollectorRegistry.defaultRegistry
       val namespace = "testnamespace"
-      new PrometheusStatsReceiver(registry, namespace, DefaultTimer.getInstance, Duration.fromSeconds(1)) must not(
+      new PrometheusStatsReceiver(registry, namespace, CustomDefaultTimer.getInstance, Duration.fromSeconds(1)) must not(
         throwA[RuntimeException])
     }
   }


### PR DESCRIPTION
@Fluxx: This supersedes #28. Take a look and let me know what you think, and I'll try and get this merged/released ASAP so that you can validate whether it helps or not. Hopefully it will.