### PR TITLE
Switch to using HashedWheelTimer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.4")
 
 organization := "com.samstarling"
 
-val finagleVersion = "18.2.0"
+val finagleVersion = "18.8.0"
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-core" % finagleVersion,

--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -3,20 +3,15 @@ package com.samstarling.prometheusfinagle
 import com.twitter.finagle.stats._
 import io.prometheus.client.{CollectorRegistry, Summary, Counter => PCounter, Gauge => PGauge}
 import scala.collection.concurrent.TrieMap
-
-import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.util.HashedWheelTimer
 import com.twitter.util._
-
-private object CustomDefaultTimer {
-  def getInstance: Timer = Option(DefaultTimer.getInstance).getOrElse(new JavaTimer(isDaemon = true))
-}
 
 class PrometheusStatsReceiver(registry: CollectorRegistry, namespace: String, timer: Timer, gaugePollInterval: Duration)
   extends StatsReceiver with Closable {
 
-  def this() = this(CollectorRegistry.defaultRegistry, "finagle", CustomDefaultTimer.getInstance, Duration.fromSeconds(10))
+  def this() = this(CollectorRegistry.defaultRegistry, "finagle", HashedWheelTimer.Default, Duration.fromSeconds(10))
 
-  def this(registry: CollectorRegistry) = this(registry, "finagle", CustomDefaultTimer.getInstance, Duration.fromSeconds(10))
+  def this(registry: CollectorRegistry) = this(registry, "finagle", HashedWheelTimer.Default, Duration.fromSeconds(10))
 
   protected val counters = TrieMap.empty[String, PCounter]
   protected val summaries = TrieMap.empty[String, Summary]

--- a/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverRaceTest.scala
+++ b/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverRaceTest.scala
@@ -5,7 +5,7 @@ import io.prometheus.client.CollectorRegistry
 import java.util.concurrent.TimeUnit
 
 class PrometheusStatsReceiverRaceTest extends UnitTest {
-  val threadCount = 10
+  val threadCount = 100
   val pool = FuturePool.unboundedPool
 
   "PrometheusStatsReceiver#counters" should {

--- a/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverTest.scala
+++ b/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverTest.scala
@@ -32,7 +32,7 @@ class PrometheusStatsReceiverTest extends UnitTest {
     "allow a registry, namespace, and a Timer to be passed" in {
       val registry = CollectorRegistry.defaultRegistry
       val namespace = "testnamespace"
-      new PrometheusStatsReceiver(registry, namespace, CustomDefaultTimer.getInstance, Duration.fromSeconds(1)) must not(
+      new PrometheusStatsReceiver(registry, namespace, DefaultTimer.twitter, Duration.fromSeconds(1)) must not(
         throwA[RuntimeException])
     }
   }


### PR DESCRIPTION
This stops the exception seen by @seanbrant in #24, by no longer using `DefaultTimer.getInstance`.

```
ERROR com.twitter.app.LoadService - LoadService: failed to instantiate 'com.samstarling.prometheusfinagle.PrometheusStatsReceiver' for the requested service 'com.twitter.finagle.stats.StatsReceiver'
java.lang.NullPointerException: null
	at com.twitter.util.ProxyTimer.schedulePeriodically(Timer.scala:148)
	at com.twitter.util.Timer.schedule(Timer.scala:56)
	at com.twitter.util.Timer.schedule$(Timer.scala:53)
```