### PR TITLE
bump finagle version and replace HashedWheelTimer with DefaultTimer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.6")
 
 organization := "com.samstarling"
 
-val finagleVersion = "19.3.0"
+val finagleVersion = "19.4.0"
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-core" % finagleVersion,

--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -2,9 +2,10 @@ package com.samstarling.prometheusfinagle
 
 import com.twitter.finagle.stats._
 import io.prometheus.client.{CollectorRegistry, Summary, Counter => PCounter, Gauge => PGauge}
+
 import scala.collection.concurrent.TrieMap
-import com.twitter.finagle.util.HashedWheelTimer
 import com.twitter.util._
+import com.twitter.finagle.util.DefaultTimer
 
 class PrometheusStatsReceiver(registry: CollectorRegistry,
                               namespace: String,
@@ -13,16 +14,17 @@ class PrometheusStatsReceiver(registry: CollectorRegistry,
     extends StatsReceiver
     with Closable {
 
+
   def this() =
     this(CollectorRegistry.defaultRegistry,
          "finagle",
-         HashedWheelTimer.Default,
+      DefaultTimer,
          Duration.fromSeconds(10))
 
   def this(registry: CollectorRegistry) =
     this(registry,
          "finagle",
-         HashedWheelTimer.Default,
+      DefaultTimer,
          Duration.fromSeconds(10))
 
   protected val counters = TrieMap.empty[String, PCounter]


### PR DESCRIPTION
fix #39 

Not sure this is the approach we want. I got a NPE when running the tests which seemed to be around the `com.twitter.app.LoadService` machinery. That being said https://github.com/twitter/finagle/blob/develop/finagle-stats-core/src/main/scala/com/twitter/finagle/stats/MetricsStatsReceiver.scala#L180 uses the `DefaultTimer` so I'm at a loss as to what we would do otherwise.