### PR TITLE
use JavaTimer instead of DefaultTimer

### DIFF
--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -18,13 +18,13 @@ class PrometheusStatsReceiver(registry: CollectorRegistry,
   def this() =
     this(CollectorRegistry.defaultRegistry,
          "finagle",
-      DefaultTimer,
+      new JavaTimer(true),
          Duration.fromSeconds(10))
 
   def this(registry: CollectorRegistry) =
     this(registry,
          "finagle",
-      DefaultTimer,
+      new JavaTimer(true),
          Duration.fromSeconds(10))
 
   protected val counters = TrieMap.empty[String, PCounter]


### PR DESCRIPTION
fix #42 
https://gitter.im/twitter/finagle?at=5cdc3c8a252dbb7515609cd4

This prevents the NPE from some kind of circular dependency triggered by LoadService between `DefaultTimer` and `PrometeusStatsReciever` and `FinagleStatsReceiver`

I set the JavaTimer to be daemonized for the following reason:     
```java
/*
   * Marks this thread as either a {@linkplain #isDaemon daemon} thread
     * or a user thread. The Java Virtual Machine exits when the only
     * threads running are all daemon threads.
```
which _seems_ to be what we want?

