### PR TITLE
Fix metric Pattern to not match metrics without labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,16 @@ scala:
   - 2.11.11
   - 2.12.6
 jdk:
-  - oraclejdk8
   - oraclejdk11
+
+matrix:
+  include:
+    - jdk: oraclejdk8
+      dist: trusty
+      scala: 2.11.11
+    - jdk: oraclejdk8
+      dist: trusty
+      scala: 2.12.6
+
 script:
   - sbt clean coverage test

--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -164,7 +164,7 @@ object DefaultMetricPatterns {
   val prometheusLabelForLabel = "serviceName"
 
   val DefaultMatch: Pattern = {
-    case label +: metrics =>
+    case label +: (metrics @ _ :: _) =>
       (sanitizeName(metrics), Map(prometheusLabelForLabel -> label))
   }
 

--- a/src/test/scala/com/samstarling/prometheusfinagle/DefaultMetricPatternsTest.scala
+++ b/src/test/scala/com/samstarling/prometheusfinagle/DefaultMetricPatternsTest.scala
@@ -89,5 +89,8 @@ class DefaultMetricPatternsTest extends UnitTest {
             .mkString)
     }
 
+    "not be defined for metrics without a parsable prefix" in {
+      DefaultMetricPatterns.All.isDefinedAt(Seq("metric_with_no_prefix")) must beFalse
+    }
   }
 }


### PR DESCRIPTION
Instead the fallback will generate a reasonable metric name. Fixes #44 