### PR TITLE
Minor bugfix when extracting metricName and labels

### DIFF
--- a/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
+++ b/src/main/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiver.scala
@@ -149,7 +149,7 @@ class PrometheusStatsReceiver(registry: CollectorRegistry,
   protected def extractLabels(
       name: Seq[String]): (String, Map[String, String]) = {
     metricPattern.applyOrElse(
-      name,
+      name.map(_.replaceAll("[^\\w]", "_")),
       (x: Seq[String]) => DefaultMetricPatterns.sanitizeName(x) -> Map.empty)
   }
 }

--- a/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverTest.scala
+++ b/src/test/scala/com/samstarling/prometheusfinagle/PrometheusStatsReceiverTest.scala
@@ -39,7 +39,7 @@ class PrometheusStatsReceiverTest extends UnitTest {
         throwA[RuntimeException])
     }
 
-    "allow handle metrics and labels with unsafe characters" in {
+    "allow metrics and labels with unsafe characters" in {
       val registry = CollectorRegistry.defaultRegistry
       val namespace = "test_metric_names_and_labels"
       val statsReceiver = new PrometheusStatsReceiver(registry,


### PR DESCRIPTION
Fixes https://github.com/samstarling/finagle-prometheus/issues/43

When including `com.samstarling.prometheusfinagle.PrometheusStatsReceiver` in `resources/META-INF/services/com.twitter.finagle.stats.StatsReceiver`  a fatal exception is encountered.  The cause is`Seq("finagle", "build/revision")`.  My proposed fix checks the input sequence and ensures the input is valid.